### PR TITLE
uninvite the unwanted

### DIFF
--- a/lib/httpalooza/lineup.rb
+++ b/lib/httpalooza/lineup.rb
@@ -2,6 +2,8 @@ module HTTPalooza
   class Lineup
     include API
 
+    UNINVITE_REGEX = /^(uninvite|but|not|except|without|save|besides?|minus|barring|excluding|omitting|exempting|other_than|apart_from|aside_from)_(.+)/i
+
     attr_reader :players
 
     def initialize
@@ -15,14 +17,28 @@ module HTTPalooza
       end
     end
 
+    def everyone
+      players.merge(Players.available)
+      self
+    end
+
     def method_missing(name, *args, &blk)
+      if uninvite = UNINVITE_REGEX.match(name)
+        name = uninvite.captures.second
+      end
+
       matched_players = Players.available.select do |player|
         name.to_s.include?(player.name.to_s)
       end
 
       return super(name, *args, &blk) if matched_players.empty?
 
-      players.merge(matched_players)
+      if uninvite
+        players.subtract(matched_players)
+      else
+        players.merge(matched_players)
+      end
+
       self
     end
   end

--- a/spec/httpalooza/lineup_spec.rb
+++ b/spec/httpalooza/lineup_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe HTTPalooza::Lineup do
+  let(:lineup) { HTTPalooza::Lineup.new }
+
+  context ".everyone" do
+    it "adds all players" do
+      expect(lineup.players).to be_empty
+      lineup.everyone
+      expect(lineup.players).to_not be_empty
+      expect(lineup.players).to match_array(HTTPalooza::Players.available)
+    end
+  end
+
+  context ".uninvite_*" do
+    it "removes players" do
+      lineup.everyone.uninvite_curl
+      expect(lineup.players).to_not include(HTTPalooza::Players::CurlPlayer)
+      expect(lineup.players).to include(HTTPalooza::Players::PatronPlayer)
+      expect(lineup.players).to include(HTTPalooza::Players::UserBrowserPlayer)
+      lineup.except_patron
+      expect(lineup.players).to_not include(HTTPalooza::Players::CurlPlayer)
+      expect(lineup.players).to_not include(HTTPalooza::Players::PatronPlayer)
+      expect(lineup.players).to include(HTTPalooza::Players::UserBrowserPlayer)
+      lineup.without_user_browser
+      expect(lineup.players).to_not include(HTTPalooza::Players::CurlPlayer)
+      expect(lineup.players).to_not include(HTTPalooza::Players::PatronPlayer)
+      expect(lineup.players).to_not include(HTTPalooza::Players::UserBrowserPlayer)
+    end
+  end
+end


### PR DESCRIPTION
```
irb(main):015:0> ap HTTPalooza.invite.everyone.other_than_curl_because_we_dont_get_along.players
[
    [0] HTTPalooza::Players::CurbPlayer < HTTPalooza::Players::Base,
    [1] HTTPalooza::Players::PatronPlayer < HTTPalooza::Players::Base,
    [2] HTTPalooza::Players::HTTPClientPlayer < HTTPalooza::Players::Base,
    [3] HTTPalooza::Players::UserBrowserPlayer < HTTPalooza::Players::Base,
    [4] HTTPalooza::Players::NetHTTPPlayer < HTTPalooza::Players::Base,
    [5] HTTPalooza::Players::RestClientPlayer < HTTPalooza::Players::Base
]
```
